### PR TITLE
feat: show file type and size on completed queue items

### DIFF
--- a/src/browser/ipc/download.js
+++ b/src/browser/ipc/download.js
@@ -211,11 +211,16 @@ function register(mainWindow, cookiePath) {
           const movedFiles = moveFromTmp(tmpDir, outDir, downloadId);
           const outputFile = movedFiles[0]?.path || null;
           const outputFileHash = movedFiles[0]?.hash || null;
+          let outputFileSize = null;
+          if (outputFile) {
+            try { outputFileSize = fs.statSync(outputFile).size; } catch {}
+          }
           mainWindow.webContents.send('download-complete', {
             downloadId,
             outputDir: outDir,
             outputFile,
             outputFileHash,
+            outputFileSize,
           });
           resolve({ success: true, outputDir: outDir, outputFile, outputFileHash });
         } else {

--- a/src/js/lib/formatters.js
+++ b/src/js/lib/formatters.js
@@ -23,9 +23,9 @@ export function formatDate(d) {
 
 export function formatBytes(b) {
   if (!b) return '';
-  if (b > 1e9) return (b / 1e9).toFixed(1) + ' GB';
-  if (b > 1e6) return (b / 1e6).toFixed(1) + ' MB';
-  if (b > 1e3) return (b / 1e3).toFixed(1) + ' KB';
+  if (b >= 1073741824) return (b / 1073741824).toFixed(1) + ' GB';
+  if (b >= 1048576) return (b / 1048576).toFixed(1) + ' MB';
+  if (b >= 1024) return (b / 1024).toFixed(1) + ' KB';
   return b + ' B';
 }
 

--- a/src/js/services/download.js
+++ b/src/js/services/download.js
@@ -128,6 +128,7 @@ export async function startDownload() {
     id: downloadId,
     title: S.videoInfo.title || 'Downloading…',
     thumb: S.videoInfo.thumbnail || '',
+    fileType: ext,
     status: 'queued',
     percent: 0,
     speed: '',

--- a/src/js/services/queue.js
+++ b/src/js/services/queue.js
@@ -1,5 +1,5 @@
 ﻿import { S } from '../state.js';
-import { escHtml, formatTs } from '../lib/formatters.js';
+import { escHtml, formatTs, formatBytes } from '../lib/formatters.js';
 import { syncOverlayToView, refreshOverlay } from '../components/ui.js';
 
 const STATUS_MAP = {
@@ -78,7 +78,7 @@ export function onProgress(data) {
 }
 
 export function onComplete(data) {
-  const { downloadId, outputDir, outputFile, outputFileHash } = data;
+  const { downloadId, outputDir, outputFile, outputFileHash, outputFileSize } = data;
   S.activeDownloadIds.delete(downloadId);
   const ts = new Date().toISOString();
   patchQueue(downloadId, {
@@ -87,6 +87,7 @@ export function onComplete(data) {
     outputDir,
     outputFile,
     outputFileHash,
+    outputFileSize: outputFileSize ?? null,
     completedAt: ts,
   });
   persistQueue();
@@ -232,7 +233,10 @@ export function updateQueueEl(el, item) {
     const parts = [pct, item.speed, item.eta ? `ETA ${item.eta}` : ''].filter(Boolean);
     stat.textContent = parts.join(' · ');
   } else if (item.status === 'done' && item.completedAt) {
-    stat.textContent = formatTs(item.completedAt);
+    const parts = [formatTs(item.completedAt)];
+    if (item.fileType) parts.push(item.fileType.toUpperCase());
+    if (item.outputFileSize != null) parts.push(formatBytes(item.outputFileSize));
+    stat.textContent = parts.join(' · ');
   } else if (item.status === 'queued') {
     stat.textContent = 'Waiting…';
   } else {


### PR DESCRIPTION
- Add outputFileSize to download-complete IPC event (fs.statSync)
- Store fileType (ext) and outputFileSize on queue items
- Display as 'timestamp · EXT · X.X MB' in queue status line
- Fix formatBytes to use 1024-based division (matches OS file size display)