### PR TITLE
feat: add playlist downloading support

### DIFF
--- a/src/browser/ipc/data.js
+++ b/src/browser/ipc/data.js
@@ -1,22 +1,22 @@
 'use strict';
 const { ipcMain } = require('electron');
-const { readJSON, writeJSON } = require('../utils/storage');
+const { readJSON, readJSONAsync, writeJSON, writeJSONAsync } = require('../utils/storage');
 const path = require('path');
 const os = require('os');
 
 function register(settingsPath, queuePath) {
   ipcMain.handle('load-settings', () => readJSON(settingsPath, {}));
-  ipcMain.handle('save-settings', (_e, data) => {
-    const cur = readJSON(settingsPath, {});
-    writeJSON(settingsPath, { ...cur, ...data });
+  ipcMain.handle('save-settings', async (_e, data) => {
+    const cur = await readJSONAsync(settingsPath, {});
+    await writeJSONAsync(settingsPath, { ...cur, ...data });
     return true;
   });
 
   ipcMain.handle('get-downloads-dir', () => path.join(os.homedir(), 'Downloads'));
 
   ipcMain.handle('load-queue', () => readJSON(queuePath, []));
-  ipcMain.handle('save-queue', (_e, data) => {
-    writeJSON(queuePath, data);
+  ipcMain.handle('save-queue', async (_e, data) => {
+    await writeJSONAsync(queuePath, data);
     return true;
   });
 }

--- a/src/browser/ipc/download.js
+++ b/src/browser/ipc/download.js
@@ -34,7 +34,7 @@ function register(mainWindow, cookiePath) {
     writeLog(`Fetching info: ${url}`);
 
     return new Promise((resolve) => {
-      const args = ['--dump-json', '--no-playlist'];
+      const args = ['--dump-single-json', '--flat-playlist'];
       if (fs.existsSync(cookiePath)) args.push('--cookies', cookiePath);
       args.push(url);
 
@@ -46,12 +46,46 @@ function register(mainWindow, cookiePath) {
       proc.on('close', (code) => {
         if (code !== 0) {
           writeLog(`fetch-info error (code ${code}): ${stderr.slice(0, 500)}`);
-          const short = 'Failed to fetch media info — check the log for details.';
-          resolve({ error: short });
+          resolve({ error: 'Failed to fetch media info — check the log for details.' });
           return;
         }
         try {
           const info = JSON.parse(stdout);
+
+          // ── Playlist ──────────────────────────────────────────────
+          if (info._type === 'playlist') {
+            const UNAVAILABLE = /^\[(Private|Deleted) video\]$/i;
+            const rawEntries = info.entries || [];
+            const entries = rawEntries
+              .filter((e) => {
+                if (!e) return false;
+                if (UNAVAILABLE.test(e.title || '')) return false;
+                if (e.availability && e.availability !== 'public') return false;
+                return true;
+              })
+              .map((e, i) => ({
+                index: i + 1,
+                title: e.title || e.id || `Video ${i + 1}`,
+                duration: e.duration || null,
+                thumbnail: e.thumbnail || e.thumbnails?.[e.thumbnails.length - 1]?.url || null,
+                url: e.url || e.webpage_url || null,
+              }));
+            const thumbnail =
+              info.thumbnails?.[info.thumbnails.length - 1]?.url || entries[0]?.thumbnail || null;
+            resolve({
+              isPlaylist: true,
+              title: info.title || info.id || 'Playlist',
+              thumbnail,
+              uploader: info.uploader || info.channel || info.uploader_id || null,
+              entryCount: entries.length,
+              entries,
+              webpage_url: info.webpage_url || url,
+              formats: [],
+            });
+            return;
+          }
+
+          // ── Single video ──────────────────────────────────────────
           const formats = (info.formats || [])
             .filter((f) => f.ext && (f.vcodec !== 'none' || f.acodec !== 'none'))
             .map((f) => ({
@@ -99,6 +133,7 @@ function register(mainWindow, cookiePath) {
       url,
       outputDir,
       formatId,
+      formatHeight,
       audioOnly,
       audioFormat,
       audioQuality,
@@ -146,25 +181,50 @@ function register(mainWindow, cookiePath) {
         String(audioQuality ?? 0)
       );
     } else {
-      let fmtStr;
       const aud = buildAudioFormatPart(videoAudioQuality, !!preferOpus);
-      if (formatId && formatId !== 'bestvideo+bestaudio/best') {
-        fmtStr = `${formatId}+${aud.m4a}/${formatId}+${aud.any}/${formatId}/best`;
+      const isWebm = container === 'webm';
+      const needsH264 = container === 'mp4' || container === 'mov';
+      const isMkv = container === 'mkv';
+
+      let fmtStr;
+      if (isWebm) {
+        // VP9/VP8 video + WebM (Opus) audio — don't use m4a audio in WebM
+        fmtStr =
+          'bestvideo[vcodec^=vp]+bestaudio[ext=webm]/bestvideo[vcodec^=vp]+bestaudio/bestvideo+bestaudio';
+      } else if (needsH264) {
+        // MP4/MOV: prefer H.264 (avc1) — VP9 cannot be stream-copied into these containers
+        const h = formatHeight ? `[height<=${formatHeight}]` : '';
+        if (formatId && formatId !== 'bestvideo+bestaudio/best') {
+          fmtStr = `bestvideo[vcodec^=avc1]${h}+${aud.m4a}/bestvideo[vcodec^=avc1]${h}+${aud.any}/${formatId}+${aud.m4a}/${formatId}+${aud.any}/${formatId}/best`;
+        } else {
+          fmtStr = `bestvideo[vcodec^=avc1]+${aud.m4a}/bestvideo[vcodec^=avc1]+${aud.any}/bestvideo[ext=mp4]+${aud.m4a}/bestvideo[ext=mp4]+${aud.any}/bestvideo+${aud.m4a}/bestvideo+${aud.any}/bestvideo+bestaudio/best`;
+        }
       } else {
-        fmtStr = `bestvideo+${aud.m4a}/bestvideo+${aud.any}/bestvideo+bestaudio/best`;
+        // MKV and others: any codec is fine
+        if (formatId && formatId !== 'bestvideo+bestaudio/best') {
+          fmtStr = `${formatId}+${aud.m4a}/${formatId}+${aud.any}/${formatId}/best`;
+        } else {
+          fmtStr = `bestvideo+${aud.m4a}/bestvideo+${aud.any}/bestvideo+bestaudio/best`;
+        }
       }
+
       args.push('-f', fmtStr);
       args.push('--merge-output-format', container || 'mp4');
-      // when Opus is preferred (or used as fallback), re-encode to AAC for Windows compatibility.
-      // -c:a aac is a no-op when the stream is already AAC (stream copy applies automatically).
-      // copy video, convert audio to aac — opus-in-mp4 not supported by windows media apps
-      args.push('--postprocessor-args', 'Merger+ffmpeg:-c:v copy -c:a aac -b:a 192k');
+
+      if (isWebm || isMkv) {
+        // Both containers support native codecs — stream copy everything
+        args.push('--postprocessor-args', 'Merger+ffmpeg:-c copy');
+      } else {
+        // MP4/MOV: stream copy H.264 video, ensure AAC audio (Opus not compatible with these containers)
+        args.push('--postprocessor-args', 'Merger+ffmpeg:-c:v copy -c:a aac -b:a 192k');
+      }
     }
 
     if (embedThumbnail) args.push('--embed-thumbnail');
     if (addMetadata) args.push('--add-metadata', '--embed-metadata');
     if (rateLimit) args.push('-r', rateLimit);
     if (playlistItems) args.push('--playlist-items', playlistItems);
+    args.push('--no-abort-on-error');
     if (fs.existsSync(cookiePath)) args.push('--cookies', cookiePath);
 
     args.push(url);

--- a/src/browser/ipc/tools.js
+++ b/src/browser/ipc/tools.js
@@ -79,10 +79,23 @@ function register(cookiePath, logPath) {
     }
   });
 
+  // Simple TTL cache so multiple playlist entries checking the same outputDir
+  // don't each fire a separate readdirSync.
+  const _dirCache = new Map();
+  const DIR_CACHE_TTL = 5000;
+
   ipcMain.handle('check-output-exists', (_e, { outputDir, title, ext }) => {
     try {
       if (!outputDir || !fs.existsSync(outputDir)) return null;
-      const files = fs.readdirSync(outputDir);
+      let files;
+      const cached = _dirCache.get(outputDir);
+      const now = Date.now();
+      if (cached && now - cached.ts < DIR_CACHE_TTL) {
+        files = cached.files;
+      } else {
+        files = fs.readdirSync(outputDir);
+        _dirCache.set(outputDir, { files, ts: now });
+      }
       const needle = title.toLowerCase().slice(0, 40);
       const extLower = ext.toLowerCase();
       const found = files.find(

--- a/src/browser/utils/logger.js
+++ b/src/browser/utils/logger.js
@@ -6,12 +6,12 @@ function init(logPath) {
   _logPath = logPath;
 }
 
+// Use async append so the main-process event loop is never blocked by log I/O.
+// Fire-and-forget: errors are silently ignored to avoid cascading issues.
 function writeLog(msg) {
   if (!_logPath) return;
   const ts = new Date().toISOString();
-  try {
-    fs.appendFileSync(_logPath, `[${ts}] ${msg}\n`);
-  } catch {}
+  fs.appendFile(_logPath, `[${ts}] ${msg}\n`, () => {});
 }
 
 module.exports = { init, writeLog };

--- a/src/browser/utils/storage.js
+++ b/src/browser/utils/storage.js
@@ -10,12 +10,30 @@ function readJSON(p, fallback) {
   }
 }
 
+async function readJSONAsync(p, fallback) {
+  try {
+    const raw = await fs.promises.readFile(p, 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return fallback;
+  }
+}
+
+async function writeJSONAsync(p, data) {
+  try {
+    // No pretty-print — compact output is faster to stringify and smaller on disk
+    await fs.promises.writeFile(p, JSON.stringify(data));
+  } catch (e) {
+    writeLog('ERROR writeJSONAsync: ' + e.message);
+  }
+}
+
 function writeJSON(p, data) {
   try {
-    fs.writeFileSync(p, JSON.stringify(data, null, 2));
+    fs.writeFileSync(p, JSON.stringify(data));
   } catch (e) {
     writeLog('ERROR writeJSON: ' + e.message);
   }
 }
 
-module.exports = { readJSON, writeJSON };
+module.exports = { readJSON, readJSONAsync, writeJSON, writeJSONAsync };

--- a/src/index.html
+++ b/src/index.html
@@ -118,6 +118,19 @@
               </div>
             </div>
 
+            <div class="playlist-panel" id="playlistPanel" style="display: none">
+              <div class="pl-header">
+                <div class="pl-thumb-wrap">
+                  <img class="pl-thumb" id="plThumb" src="" alt="" />
+                </div>
+                <div class="pl-meta">
+                  <div class="pl-title" id="plTitle"></div>
+                  <div class="pl-sub" id="plSub"></div>
+                </div>
+              </div>
+              <div class="pl-list" id="plList"></div>
+            </div>
+
             <div class="options-panel" id="optionsPanel" style="display: none">
               <div class="tab-bar">
                 <button class="tab active" data-tab="media" data-i18n="tab_media">Media</button>
@@ -219,7 +232,7 @@
                     <input type="checkbox" id="chkMeta" checked /><span class="slider"></span>
                   </label>
                 </div>
-                <div class="field-row">
+                <div class="field-row" id="customFilenameRow">
                   <span class="field-label" data-i18n="label_filename">Custom Filename</span>
                   <input
                     type="text"
@@ -239,7 +252,7 @@
                     placeholder="e.g. 2M, 500K"
                   />
                 </div>
-                <div class="field-row">
+                <div class="field-row" id="playlistItemsRow" style="display: none">
                   <span class="field-label" data-i18n="label_playlist">Playlist Items</span>
                   <input
                     type="text"
@@ -567,6 +580,32 @@
         <span id="dlOvPct">0%</span>
         <span id="dlOvSpeed"></span>
         <span id="dlOvEta"></span>
+      </div>
+    </div>
+
+    <div class="modal-overlay" id="playlistOverwriteModal" style="display: none">
+      <div class="modal-box ow-modal-box">
+        <div class="ow-icon">
+          <svg
+            viewBox="0 0 24 24"
+            width="40"
+            height="40"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle cx="12" cy="12" r="11" fill="var(--warn)" opacity="0.15" />
+            <circle cx="12" cy="12" r="11" stroke="var(--warn)" stroke-width="1.6" />
+            <rect x="11" y="7" width="2" height="6" rx="1" fill="var(--warn)" />
+            <circle cx="12" cy="16.5" r="1.2" fill="var(--warn)" />
+          </svg>
+        </div>
+        <div class="ow-title">Files already exist</div>
+        <div class="ow-msg" id="plOwMsg">Some files already exist in the output folder.</div>
+        <div class="ow-actions">
+          <button class="btn-secondary" id="btnPlOwCancel">Cancel</button>
+          <button class="btn-secondary" id="btnPlOwSkip">Skip Existing</button>
+          <button class="btn-ow-replace" id="btnPlOwOverwrite">Overwrite All</button>
+        </div>
       </div>
     </div>
 

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -109,9 +109,17 @@ function setupListeners() {
   document.getElementById('btnCancelDl').onclick = handleCancelActive;
 
   document.getElementById('btnClearDone').addEventListener('pointerdown', () => {
-    const removable = ['done', 'cancelled', 'error'];
-    S.queue = S.queue.filter((q) => !removable.includes(q.status));
-    document.querySelectorAll('.queue-item').forEach((el) => {
+    const removable = new Set(['done', 'cancelled', 'error']);
+    // collect finished group IDs so their children are swept too
+    const removedGroupIds = new Set(
+      S.queue.filter((q) => q.isPlaylistGroup && removable.has(q.status)).map((q) => q.id)
+    );
+    S.queue = S.queue.filter((q) => {
+      if (q.isPlaylistGroup) return !removedGroupIds.has(q.id);
+      if (q.parentId) return !removedGroupIds.has(q.parentId);
+      return !removable.has(q.status);
+    });
+    document.querySelectorAll('.queue-item, .qi-group').forEach((el) => {
       const id = el.id.replace('qi-', '');
       if (!S.queue.find((q) => q.id === id)) el.remove();
     });

--- a/src/js/components/ui.js
+++ b/src/js/components/ui.js
@@ -72,6 +72,24 @@ export function setView(name) {
   syncOverlayToView();
 }
 
+export function showPlaylistOverwriteModal(conflictCount, totalCount) {
+  return new Promise((resolve) => {
+    const overlay = document.getElementById('playlistOverwriteModal');
+    document.getElementById('plOwMsg').textContent =
+      `${conflictCount} of ${totalCount} files already exist in the output folder.`;
+    overlay.style.display = 'flex';
+
+    const cleanup = (choice) => {
+      overlay.style.display = 'none';
+      resolve(choice);
+    };
+
+    document.getElementById('btnPlOwCancel').onclick = () => cleanup('cancel');
+    document.getElementById('btnPlOwSkip').onclick = () => cleanup('skip');
+    document.getElementById('btnPlOwOverwrite').onclick = () => cleanup('overwrite');
+  });
+}
+
 export function showOverwriteModal(filename, i18nT) {
   return new Promise((resolve) => {
     const overlay = document.getElementById('overwriteModal');

--- a/src/js/services/download.js
+++ b/src/js/services/download.js
@@ -1,9 +1,10 @@
 ﻿import { S } from '../state.js';
 import { t } from '../lib/i18n.js';
 import { formatDuration, formatCount, formatDate, escHtml } from '../lib/formatters.js';
-import { showToast, showOverwriteModal } from '../components/ui.js';
+import { showToast, showOverwriteModal, showPlaylistOverwriteModal } from '../components/ui.js';
 import {
   enqueueDownload,
+  enqueuePlaylistGroup,
   cancelActive,
   onProgress,
   onComplete,
@@ -16,6 +17,7 @@ export async function fetchInfo() {
   if (!url) return;
 
   document.getElementById('infoCard').style.display = 'none';
+  document.getElementById('playlistPanel').style.display = 'none';
   document.getElementById('optionsPanel').style.display = 'none';
   document.getElementById('loadingState').style.display = 'flex';
   document.getElementById('btnFetch').disabled = true;
@@ -32,9 +34,24 @@ export async function fetchInfo() {
   }
 
   S.videoInfo = info;
-  populateInfo(info);
-  populateFormats(info.formats || []);
-  document.getElementById('infoCard').style.display = '';
+
+  if (info.isPlaylist) {
+    populatePlaylist(info);
+    document.getElementById('playlistPanel').style.display = '';
+    document.getElementById('infoCard').style.display = 'none';
+    document.getElementById('playlistItemsRow').style.display = '';
+    document.getElementById('customFilenameRow').style.display = 'none';
+    document.getElementById('customFilename').value = '';
+  } else {
+    populateInfo(info);
+    populateFormats(info.formats || []);
+    document.getElementById('infoCard').style.display = '';
+    document.getElementById('playlistPanel').style.display = 'none';
+    document.getElementById('playlistItemsRow').style.display = 'none';
+    document.getElementById('playlistItems').value = '';
+    document.getElementById('customFilenameRow').style.display = '';
+  }
+
   document.getElementById('optionsPanel').style.display = '';
   document.getElementById('btnDownload').disabled = false;
 }
@@ -52,6 +69,33 @@ function populateInfo(info) {
   if (info.view_count) parts.push(escHtml(formatCount(info.view_count) + ' views'));
   if (info.upload_date) parts.push(escHtml(formatDate(info.upload_date)));
   subEl.innerHTML = parts.join('<span class="sep"> · </span>');
+}
+
+function populatePlaylist(info) {
+  document.getElementById('plThumb').src = info.thumbnail || '';
+  document.getElementById('plTitle').textContent = info.title || 'Playlist';
+
+  const parts = [];
+  if (info.entryCount) parts.push(`${info.entryCount} videos`);
+  if (info.uploader) parts.push(escHtml(info.uploader));
+  document.getElementById('plSub').textContent = parts.join(' · ');
+
+  const list = document.getElementById('plList');
+  list.innerHTML = '';
+  (info.entries || []).forEach((entry) => {
+    const wrap = document.createElement('div');
+    wrap.className = 'pl-entry';
+    const dur = entry.duration ? formatDuration(entry.duration) : '';
+    wrap.innerHTML = `
+      <span class="pl-entry-num">${entry.index}</span>
+      <div class="pl-entry-thumb-wrap">
+        <img class="pl-entry-thumb" src="${escHtml(entry.thumbnail || '')}" alt="" />
+        ${dur ? `<span class="pl-entry-dur">${escHtml(dur)}</span>` : ''}
+      </div>
+      <span class="pl-entry-title">${escHtml(entry.title)}</span>
+    `;
+    list.appendChild(wrap);
+  });
 }
 
 function populateFormats(formats) {
@@ -88,6 +132,110 @@ export async function startDownload() {
   const audioFormat = document.getElementById('audioFmtSelect').value;
   const container = document.getElementById('containerSelect').value;
   const ext = audioOnly ? audioFormat : container;
+
+  // ── Playlist: one child download per entry ───────────────────────
+  if (S.videoInfo.isPlaylist) {
+    let entries = S.videoInfo.entries || [];
+    if (!entries.length) return;
+
+    const groupId = `dl_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
+    const sharedOpts = {
+      outputDir,
+      formatId: audioOnly ? null : document.getElementById('fmtSelect').value,
+      audioOnly,
+      audioFormat,
+      audioQuality: document.getElementById('audioQualSelect').value,
+      videoAudioQuality: document.getElementById('videoAudioQualSelect')?.value || '0',
+      preferOpus: !!S.settings.preferOpus,
+      embedThumbnail: document.getElementById('chkThumb').checked,
+      addMetadata: document.getElementById('chkMeta').checked,
+      rateLimit: document.getElementById('rateLimit').value.trim() || null,
+      container,
+      forceOverwrite: !!S.settings.alwaysOverwrite,
+      customFilename: null,
+    };
+
+    // Apply playlist items filter (e.g. "1-3,5") before building child jobs
+    const playlistItemsVal = document.getElementById('playlistItems').value.trim();
+    if (playlistItemsVal) {
+      const allowed = new Set();
+      for (const part of playlistItemsVal.split(',')) {
+        const range = part.trim().split('-');
+        if (range.length === 2) {
+          const a = parseInt(range[0], 10);
+          const b = parseInt(range[1], 10);
+          if (!isNaN(a) && !isNaN(b)) for (let n = a; n <= b; n++) allowed.add(n);
+        } else {
+          const n = parseInt(range[0], 10);
+          if (!isNaN(n)) allowed.add(n);
+        }
+      }
+      entries = entries.filter((e) => allowed.has(e.index));
+    }
+    if (!entries.length) return;
+
+    // ── Overwrite check ──────────────────────────────────────────────
+    if (!S.settings.alwaysOverwrite && outputDir) {
+      const existChecks = await Promise.all(
+        entries.map((entry) =>
+          window.api
+            .checkOutputExists({ outputDir, title: entry.title, ext })
+            .then((p) => (p ? entry : null))
+        )
+      );
+      const conflicting = existChecks.filter(Boolean);
+      if (conflicting.length) {
+        const choice = await showPlaylistOverwriteModal(conflicting.length, entries.length);
+        if (choice === 'cancel') return;
+        if (choice === 'skip') {
+          const conflictSet = new Set(conflicting.map((e) => e.index));
+          entries = entries.filter((e) => !conflictSet.has(e.index));
+          if (!entries.length) return;
+        }
+        // 'overwrite' → keep all entries, forceOverwrite already false but flip it
+        if (choice === 'overwrite') sharedOpts.forceOverwrite = true;
+      }
+    }
+
+    const group = {
+      id: groupId,
+      title: S.videoInfo.title || 'Playlist',
+      thumb: S.videoInfo.thumbnail || '',
+      isPlaylistGroup: true,
+      status: 'queued',
+      percent: 0,
+      doneCount: 0,
+      totalCount: entries.length,
+      outputDir,
+    };
+
+    const children = entries.map((entry, i) => {
+      const childId = `${groupId}_${i}`;
+      return {
+        id: childId,
+        parentId: groupId,
+        title: entry.title || `Video ${entry.index}`,
+        thumb: entry.thumbnail || S.videoInfo.thumbnail || '',
+        fileType: ext,
+        status: 'queued',
+        percent: 0,
+        speed: '',
+        eta: '',
+        outputDir,
+        opts: {
+          ...sharedOpts,
+          url: entry.url,
+          downloadId: childId,
+          playlistItems: null,
+        },
+      };
+    });
+
+    enqueuePlaylistGroup(group, children);
+    return;
+  }
+
+  // ── Single video ─────────────────────────────────────────────────
   const title =
     document.getElementById('customFilename')?.value.trim() || S.videoInfo.title || 'download';
 
@@ -105,10 +253,23 @@ export async function startDownload() {
 
   const downloadId = `dl_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
 
+  const fmtSelectValue = audioOnly ? null : document.getElementById('fmtSelect').value;
+  const selectedFmt =
+    fmtSelectValue && fmtSelectValue !== 'bestvideo+bestaudio/best'
+      ? (S.videoInfo?.formats || []).find((f) => f.format_id === fmtSelectValue)
+      : null;
+  // Extract height from resolution string e.g. "1920x1080" or "1080p60"
+  const formatHeight = selectedFmt?.resolution
+    ? parseInt((selectedFmt.resolution.match(/\d+x(\d+)/) || [])[1]) ||
+      parseInt((selectedFmt.resolution.match(/^(\d+)p/) || [])[1]) ||
+      null
+    : null;
+
   const opts = {
     url: S.videoInfo.webpage_url || document.getElementById('urlInput').value.trim(),
     outputDir,
-    formatId: audioOnly ? null : document.getElementById('fmtSelect').value,
+    formatId: fmtSelectValue,
+    formatHeight,
     audioOnly,
     audioFormat,
     audioQuality: document.getElementById('audioQualSelect').value,
@@ -168,4 +329,54 @@ export function wireDownloadEvents() {
     showToast('Download failed — check Settings → Logs for details.', 'error');
   });
   window.api.onCancelled(onCancelled);
+
+  document.getElementById('playlistItems').addEventListener('input', (e) => {
+    const max = S.videoInfo?.entryCount;
+    if (!max || max < 1) return;
+    sanitizePlaylistItems(e.target, max);
+  });
+}
+
+function sanitizePlaylistItems(input, max) {
+  const orig = input.value;
+  const cursor = input.selectionStart;
+  const endsWithComma = orig.endsWith(',');
+
+  const parts = orig.replace(/[^\d\-,]/g, '').split(',');
+
+  const sanitized = parts.map((part) => {
+    if (!part) return '';
+    const dashIdx = part.indexOf('-');
+
+    if (dashIdx === -1) {
+      const n = parseInt(part, 10);
+      if (isNaN(n) || n < 1) return '';
+      return String(Math.min(n, max));
+    }
+
+    if (dashIdx === 0) return ''; // leading dash — not a range separator
+
+    const aStr = part.slice(0, dashIdx);
+    const bStr = part.slice(dashIdx + 1);
+    const a = parseInt(aStr, 10);
+    if (isNaN(a)) return '';
+    const aVal = Math.min(Math.max(a, 1), max);
+
+    if (!bStr) return `${aVal}-`; // partial range, e.g. "3-"
+
+    const b = parseInt(bStr, 10);
+    if (isNaN(b)) return `${aVal}-`;
+    const bVal = Math.min(Math.max(b, aVal), max);
+    return `${aVal}-${bVal}`;
+  });
+
+  let result = sanitized.filter((p) => p !== '').join(',');
+  if (endsWithComma) result += ',';
+
+  if (result !== orig) {
+    const diff = result.length - orig.length;
+    input.value = result;
+    const pos = Math.max(0, Math.min(cursor + diff, result.length));
+    input.setSelectionRange(pos, pos);
+  }
 }

--- a/src/js/services/queue.js
+++ b/src/js/services/queue.js
@@ -15,7 +15,9 @@ const STATUS_MAP = {
 };
 
 export function updateBadge() {
-  const n = S.queue.filter((q) => q.status === 'downloading' || q.status === 'queued').length;
+  const n = S.queue.filter(
+    (q) => q.opts && (q.status === 'downloading' || q.status === 'queued')
+  ).length;
   const badge = document.getElementById('queueBadge');
   badge.style.display = n > 0 ? '' : 'none';
   badge.textContent = n;
@@ -33,7 +35,7 @@ export function processNextInQueue() {
   const max = Number(S.settings.maxConcurrent) || 1;
 
   while (S.activeDownloadIds.size < max) {
-    const next = S.queue.find((q) => q.status === 'queued');
+    const next = S.queue.find((q) => q.status === 'queued' && q.opts);
     if (!next) break;
 
     next.status = 'downloading';
@@ -122,16 +124,58 @@ export function onCancelled(data) {
 }
 
 export function cancelSpecific(id) {
+  const item = S.queue.find((q) => q.id === id);
+  if (item?.isPlaylistGroup) {
+    const children = S.queue.filter((q) => q.parentId === id);
+    children.forEach((c) => {
+      if (S.activeDownloadIds.has(c.id)) {
+        window.api.cancelDownload(c.id);
+      } else if (c.status === 'queued') {
+        c.status = 'cancelled';
+        c.percent = 0;
+        updateQueueEl(document.getElementById(`qi-${c.id}`), c);
+      }
+    });
+    updateGroupFromChildren(id);
+    processNextInQueue();
+    persistQueue();
+    return;
+  }
   if (!S.activeDownloadIds.has(id)) return;
   window.api.cancelDownload(id);
 }
 
 export function removeFromQueue(id) {
-  if (S.activeDownloadIds.has(id)) {
-    window.api.cancelDownload(id);
+  const item = S.queue.find((q) => q.id === id);
+  if (item?.isPlaylistGroup) {
+    removePlaylistGroup(id);
+    return;
   }
+  if (S.activeDownloadIds.has(id)) window.api.cancelDownload(id);
+  const parentId = item?.parentId;
   S.queue = S.queue.filter((q) => q.id !== id);
   S.activeDownloadIds.delete(id);
+  const el = document.getElementById(`qi-${id}`);
+  if (el) el.remove();
+  if (parentId) {
+    updateGroupFromChildren(parentId);
+  } else {
+    updateEmptyState();
+    updateBadge();
+    persistQueue();
+  }
+  refreshOverlay();
+  syncOverlayToView();
+}
+
+function removePlaylistGroup(id) {
+  const children = S.queue.filter((q) => q.parentId === id);
+  children.forEach((c) => {
+    if (S.activeDownloadIds.has(c.id)) window.api.cancelDownload(c.id);
+    S.activeDownloadIds.delete(c.id);
+  });
+  const allIds = new Set([id, ...children.map((c) => c.id)]);
+  S.queue = S.queue.filter((q) => !allIds.has(q.id));
   const el = document.getElementById(`qi-${id}`);
   if (el) el.remove();
   updateEmptyState();
@@ -143,7 +187,10 @@ export function removeFromQueue(id) {
 
 export function cancelActive() {
   const id = primaryActiveId();
-  if (id) cancelSpecific(id);
+  if (!id) return;
+  const item = S.queue.find((q) => q.id === id);
+  const targetId = item?.parentId || id;
+  cancelSpecific(targetId);
 }
 
 export async function persistQueue() {
@@ -166,18 +213,35 @@ export async function persistQueue() {
 export function renderQueue() {
   const list = document.getElementById('queueList');
   S.queue.forEach((item) => {
-    if (!document.getElementById(`qi-${item.id}`)) {
-      list.appendChild(buildQueueEl(item));
+    if (item.isPlaylistGroup) {
+      if (!document.getElementById(`qi-${item.id}`)) {
+        const kids = S.queue.filter((q) => q.parentId === item.id);
+        list.appendChild(buildGroupEl(item, kids));
+      }
+      updateGroupEl(document.getElementById(`qi-${item.id}`), item);
+    } else if (item.parentId) {
+      if (!document.getElementById(`qi-${item.id}`)) {
+        const parentEl = document.getElementById(`qi-${item.parentId}`);
+        if (parentEl) {
+          const childrenDiv = parentEl.querySelector('.qi-children');
+          if (childrenDiv) childrenDiv.appendChild(buildQueueEl(item, true));
+        }
+      }
+      updateQueueEl(document.getElementById(`qi-${item.id}`), item);
+    } else {
+      if (!document.getElementById(`qi-${item.id}`)) {
+        list.appendChild(buildQueueEl(item));
+      }
+      updateQueueEl(document.getElementById(`qi-${item.id}`), item);
     }
-    updateQueueEl(document.getElementById(`qi-${item.id}`), item);
   });
   updateEmptyState();
   updateBadge();
 }
 
-export function buildQueueEl(item) {
+export function buildQueueEl(item, isChild = false) {
   const el = document.createElement('div');
-  el.className = 'queue-item';
+  el.className = isChild ? 'qi-child' : 'queue-item';
   el.id = `qi-${item.id}`;
   el.innerHTML = `
     <img class="qi-thumb" src="${escHtml(item.thumb || '')}" alt=""/>
@@ -239,6 +303,8 @@ export function updateQueueEl(el, item) {
     stat.textContent = parts.join(' · ');
   } else if (item.status === 'queued') {
     stat.textContent = 'Waiting…';
+  } else if (item.status === 'error') {
+    stat.textContent = 'Download failed';
   } else {
     stat.textContent = '';
   }
@@ -324,4 +390,204 @@ export function patchQueue(id, patch) {
   const item = S.queue.find((q) => q.id === id);
   if (item) Object.assign(item, patch);
   updateQueueEl(document.getElementById(`qi-${id}`), item);
+  if (item?.parentId) updateGroupFromChildren(item.parentId);
+}
+
+function updateGroupFromChildren(groupId) {
+  const group = S.queue.find((q) => q.id === groupId);
+  if (!group) return;
+  const children = S.queue.filter((q) => q.parentId === groupId);
+
+  // No children left — remove the group itself cleanly
+  if (!children.length) {
+    S.queue = S.queue.filter((q) => q.id !== groupId);
+    const el = document.getElementById(`qi-${groupId}`);
+    if (el) el.remove();
+    updateEmptyState();
+    updateBadge();
+    persistQueue();
+    return;
+  }
+
+  const total = children.length;
+  const doneCount = children.filter((c) => c.status === 'done').length;
+  const downloading = children.some((c) => c.status === 'downloading');
+  const queued = children.some((c) => c.status === 'queued');
+  group.doneCount = doneCount;
+  group.totalCount = total;
+  group.percent = children.reduce((s, c) => s + (c.percent || 0), 0) / total;
+  if (doneCount === total) {
+    group.status = 'done';
+    const timestamps = children.map((c) => c.completedAt).filter(Boolean);
+    group.completedAt = timestamps.length ? timestamps.sort().at(-1) : new Date().toISOString();
+    const types = [...new Set(children.map((c) => c.fileType).filter(Boolean))];
+    group.fileType = types.join('/');
+    const sizes = children.map((c) => c.outputFileSize).filter((v) => v != null);
+    group.outputFileSize = sizes.length ? sizes.reduce((a, b) => a + b, 0) : null;
+  } else if (downloading) group.status = 'downloading';
+  else if (queued) group.status = 'queued';
+  else if (children.some((c) => c.status === 'error')) group.status = 'error';
+  else group.status = 'cancelled';
+  const el = document.getElementById(`qi-${groupId}`);
+  updateGroupEl(el, group);
+  updateBadge();
+}
+
+function buildGroupEl(group, children) {
+  const outer = document.createElement('div');
+  outer.className = 'qi-group';
+  outer.id = `qi-${group.id}`;
+
+  const header = document.createElement('div');
+  header.className = 'qi-group-header';
+  header.innerHTML = `
+    <img class="qi-thumb" src="${escHtml(group.thumb || '')}" alt=""/>
+    <div class="qi-body">
+      <div class="qi-title">${escHtml(group.title)}</div>
+      <div class="qi-row">
+        <div class="qi-pw"><div class="qi-p" style="width:0%"></div></div>
+        <span class="qi-badge queued">Queued</span>
+        <div class="qi-btns">
+          <button class="qi-cancel" title="Cancel all downloads">
+            <svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2">
+              <line x1="1" y1="1" x2="11" y2="11"/><line x1="11" y1="1" x2="1" y2="11"/>
+            </svg>
+          </button>
+          <button class="qi-retry" style="display:none" title="Retry all">
+            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M2 8a6 6 0 1 0 1-3.3"/>
+              <polyline points="2,2 2,5 5,5"/>
+            </svg>
+          </button>
+          <button class="qi-action" style="display:none"></button>
+          <button class="qi-expand" title="Show items" ${children.length === 0 ? 'style="display:none"' : ''}>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2">
+              <polyline points="6 9 12 15 18 9"/>
+            </svg>
+          </button>
+        </div>
+      </div>
+      <div class="qi-status">0 / ${children.length} done</div>
+    </div>
+  `;
+  outer.appendChild(header);
+
+  const childrenDiv = document.createElement('div');
+  childrenDiv.className = 'qi-children';
+  children.forEach((child) => childrenDiv.appendChild(buildQueueEl(child, true)));
+  outer.appendChild(childrenDiv);
+
+  const cancelBtn = header.querySelector('.qi-cancel');
+  cancelBtn.addEventListener('click', () => cancelSpecific(group.id));
+
+  header.querySelector('.qi-retry').addEventListener('click', () => retryGroup(group.id));
+
+  header.querySelector('.qi-expand').addEventListener('click', () => {
+    outer.classList.toggle('open');
+    childrenDiv.classList.toggle('expanded');
+  });
+
+  return outer;
+}
+
+function updateGroupEl(el, group) {
+  if (!el) return;
+  const p = el.querySelector(':scope > .qi-group-header .qi-p');
+  const badge = el.querySelector(':scope > .qi-group-header .qi-badge');
+  const stat = el.querySelector(':scope > .qi-group-header .qi-status');
+  const act = el.querySelector(':scope > .qi-group-header .qi-action');
+  if (!p || !badge || !stat) return;
+  const s = STATUS_MAP[group.status] || STATUS_MAP.queued;
+  p.style.width = `${group.percent || 0}%`;
+  p.style.background = s.color;
+  badge.textContent = s.label;
+  badge.className = `qi-badge ${s.cls}`;
+  const done = group.doneCount ?? 0;
+  const total = group.totalCount ?? 0;
+  if (group.status === 'done') {
+    const parts = [];
+    if (group.completedAt) parts.push(formatTs(group.completedAt));
+    if (group.fileType) parts.push(group.fileType.toUpperCase());
+    if (group.outputFileSize != null) parts.push(formatBytes(group.outputFileSize));
+    parts.push(`${total}/${total}`);
+    stat.textContent = parts.join(' · ');
+  } else {
+    stat.textContent = `${done}/${total}`;
+  }
+  const expandBtn = el.querySelector(':scope > .qi-group-header .qi-expand');
+  if (expandBtn) {
+    const childCount = S.queue.filter((q) => q.parentId === group.id).length;
+    expandBtn.style.display = childCount > 0 ? '' : 'none';
+  }
+  const retryBtn = el.querySelector(':scope > .qi-group-header .qi-retry');
+  if (retryBtn) {
+    if (group.status === 'cancelled' || group.status === 'error') {
+      retryBtn.style.display = '';
+      retryBtn.onclick = () => retryGroup(group.id);
+    } else {
+      retryBtn.style.display = 'none';
+      retryBtn.onclick = null;
+    }
+  }
+  const cancelBtn = el.querySelector(':scope > .qi-group-header .qi-cancel');
+  if (cancelBtn) {
+    if (group.status === 'queued' || group.status === 'downloading') {
+      cancelBtn.style.display = '';
+      cancelBtn.onclick = () => cancelSpecific(group.id);
+    } else {
+      cancelBtn.style.display = 'none';
+      cancelBtn.onclick = null;
+    }
+  }
+  if (act) {
+    if (['done', 'cancelled', 'error'].includes(group.status)) {
+      act.style.display = '';
+      act.textContent = 'Remove';
+      act.onclick = () => removePlaylistGroup(group.id);
+    } else {
+      act.style.display = 'none';
+      act.onclick = null;
+    }
+  }
+}
+
+function retryGroup(groupId) {
+  const children = S.queue.filter((q) => q.parentId === groupId);
+  const retryable = children.filter(
+    (c) => (c.status === 'cancelled' || c.status === 'error') && c.opts
+  );
+  if (!retryable.length) return;
+
+  retryable.forEach((child) => {
+    const oldId = child.id;
+    const newId = `${oldId}_r${Date.now().toString(36)}`;
+    S.cancelledIds.delete(oldId);
+    child.id = newId;
+    child.opts = { ...child.opts, downloadId: newId };
+    child.status = 'queued';
+    child.percent = 0;
+    child.speed = null;
+    child.eta = null;
+    const el = document.getElementById(`qi-${oldId}`);
+    if (el) {
+      el.id = `qi-${newId}`;
+      updateQueueEl(el, child);
+    }
+  });
+
+  updateGroupFromChildren(groupId);
+  persistQueue();
+  processNextInQueue();
+}
+
+export function enqueuePlaylistGroup(group, children) {
+  S.queue.unshift(group);
+  children.forEach((c, i) => S.queue.splice(1 + i, 0, c));
+  const list = document.getElementById('queueList');
+  const el = buildGroupEl(group, children);
+  list.insertBefore(el, list.firstChild);
+  updateEmptyState();
+  persistQueue();
+  updateBadge();
+  processNextInQueue();
 }

--- a/src/style.css
+++ b/src/style.css
@@ -215,6 +215,13 @@ body::after {
   overflow-y: auto;
   padding: 20px;
   gap: 14px;
+  background:
+    linear-gradient(var(--bg) 30%, transparent) center top / 100% 40px no-repeat local,
+    linear-gradient(transparent, var(--bg) 70%) center bottom / 100% 40px no-repeat local,
+    radial-gradient(farthest-side at 50% 0%, rgba(0, 0, 0, 0.28), transparent) center top / 100%
+      14px no-repeat scroll,
+    radial-gradient(farthest-side at 50% 100%, rgba(0, 0, 0, 0.28), transparent) center bottom /
+      100% 14px no-repeat scroll;
 }
 .view.active {
   display: flex;
@@ -234,6 +241,13 @@ body::after {
   gap: 14px;
   /* bottom padding so content doesn't hide behind sticky footer */
   padding-bottom: 8px;
+  background:
+    linear-gradient(var(--bg) 30%, transparent) center top / 100% 40px no-repeat local,
+    linear-gradient(transparent, var(--bg) 70%) center bottom / 100% 40px no-repeat local,
+    radial-gradient(farthest-side at 50% 0%, rgba(0, 0, 0, 0.28), transparent) center top / 100%
+      14px no-repeat scroll,
+    radial-gradient(farthest-side at 50% 100%, rgba(0, 0, 0, 0.28), transparent) center bottom /
+      100% 14px no-repeat scroll;
 }
 /* Sticky download footer — always visible; button is disabled until a URL is fetched */
 .dl-footer {
@@ -425,6 +439,119 @@ body::after {
   border-radius: var(--r);
   overflow: hidden;
   animation: fadeUp 0.25s;
+}
+
+/* ─── Playlist panel ─────────────────────────────────────────────── */
+.playlist-panel {
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: var(--r);
+  overflow: hidden;
+  animation: fadeUp 0.25s;
+  flex-shrink: 0;
+}
+.pl-header {
+  display: flex;
+  gap: 14px;
+  padding: 14px;
+  border-bottom: 1px solid var(--border);
+}
+.pl-thumb-wrap {
+  flex-shrink: 0;
+  width: 144px;
+  height: 82px;
+  border-radius: 6px;
+  overflow: hidden;
+  background: var(--bg4);
+}
+.pl-thumb {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.pl-meta {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 5px;
+}
+.pl-title {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.3;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+.pl-sub {
+  font-size: 12px;
+  color: var(--text2);
+}
+.pl-list {
+  max-height: 260px;
+  overflow-y: auto;
+  background:
+    linear-gradient(var(--bg2) 30%, transparent) center top / 100% 36px no-repeat local,
+    linear-gradient(transparent, var(--bg2) 70%) center bottom / 100% 36px no-repeat local,
+    radial-gradient(farthest-side at 50% 0%, rgba(0, 0, 0, 0.28), transparent) center top / 100%
+      12px no-repeat scroll,
+    radial-gradient(farthest-side at 50% 100%, rgba(0, 0, 0, 0.28), transparent) center bottom /
+      100% 12px no-repeat scroll;
+}
+.pl-entry {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 14px;
+  border-bottom: 1px solid var(--border);
+}
+.pl-entry:last-child {
+  border-bottom: none;
+}
+.pl-entry-num {
+  font-size: 11px;
+  color: var(--text3);
+  font-family: var(--mono);
+  width: 24px;
+  text-align: right;
+  flex-shrink: 0;
+}
+.pl-entry-thumb-wrap {
+  position: relative;
+  flex-shrink: 0;
+  width: 80px;
+  height: 45px;
+  border-radius: 4px;
+  overflow: hidden;
+  background: var(--bg4);
+}
+.pl-entry-thumb {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.pl-entry-dur {
+  position: absolute;
+  bottom: 3px;
+  right: 4px;
+  background: rgba(0, 0, 0, 0.78);
+  color: #fff;
+  font-size: 10px;
+  font-family: var(--mono);
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+.pl-entry-title {
+  flex: 1;
+  min-width: 0;
+  font-size: 13px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 /* ─── Tab bar ───────────────────────────────────────────────────── */
@@ -1011,6 +1138,67 @@ body::after {
   background: var(--accent);
   margin-left: auto;
 }
+
+/* ─── Playlist group queue item ─────────────────────────────────── */
+.qi-group {
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: var(--r);
+  overflow: hidden;
+  animation: fadeUp 0.2s;
+}
+.qi-group-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 11px 14px;
+}
+.qi-children {
+  display: none;
+  border-top: 1px solid var(--border);
+}
+.qi-children.expanded {
+  display: block;
+}
+.qi-child {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 14px 8px 20px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg3);
+}
+.qi-child:last-child {
+  border-bottom: none;
+}
+.qi-expand {
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  border: 1px solid transparent;
+  color: var(--text3);
+  transition:
+    background 0.15s,
+    color 0.15s;
+}
+.qi-expand svg {
+  width: 14px;
+  height: 14px;
+  transition: transform 0.2s;
+  pointer-events: none;
+}
+.qi-group.open .qi-expand svg {
+  transform: rotate(180deg);
+}
+.qi-expand:hover {
+  background: var(--bg4);
+  color: var(--text);
+}
+
 .update-status-text {
   font-size: 12.5px;
   color: var(--text3);


### PR DESCRIPTION
- Fetch playlist info via --flat-playlist, show entries in UI
- Queue architecture: group header + child items per video
- Group cancel/retry from header and overlay X button
- Overwrite check for playlists: skip existing or overwrite all
- Custom filename field hidden for playlists, shown for singles
- Group done status shows timestamp, file type, total size and N/N count
- Overlay cancel cancels entire playlist group if active child belongs to one